### PR TITLE
Adds "demoURL" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ui-responsive-toolbelt": "0.0.5"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://development.ui-list.divshot.io/"
   }
 }


### PR DESCRIPTION
Sites likes emberaddons.com and emberobserver.com will display a link to "demoURL".